### PR TITLE
4723 Don't strip status from CoreApiClient methods

### DIFF
--- a/tests/test_thiscovery_api_utils/test_core_api_utilities.py
+++ b/tests/test_thiscovery_api_utils/test_core_api_utilities.py
@@ -18,6 +18,7 @@
 import local.dev_config  # sets env variables TEST_ON_AWS and AWS_TEST_API
 import local.secrets  # sets env variables THISCOVERY_AFS25_PROFILE and THISCOVERY_AMP205_PROFILE
 
+import json
 import random
 import string
 import thiscovery_dev_tools.testing_tools as test_utils
@@ -57,7 +58,15 @@ class TestCoreApiUtilities(test_utils.BaseTestCase):
             "title": "Mr",
             "last_login": "2018-08-17T12:10:56.833885+00:00",
         }
-        self.assertEqual(expected_user, result)
+        expected_status_code = HTTPStatus.OK
+        self.assertDictEqual(expected_user, json.loads(result["body"]))
+        self.assertEqual(expected_status_code, result["statusCode"])
+
+    def test_get_user_by_user_id_not_found(self):
+        result = self.core_client.get_user_by_user_id(
+            "1cbe9aad-b29f-46b5-920e-b4c496d42516"
+        )
+        self.assertEqual(HTTPStatus.NOT_FOUND, result["statusCode"])
 
     def test_get_user_by_email_ok(self):
         result = self.core_client.get_user_by_email(email="delia@email.co.uk")
@@ -72,6 +81,12 @@ class TestCoreApiUtilities(test_utils.BaseTestCase):
             anon_project_specific_user_id="1a03cb39-b669-44bb-a69e-98e6a521d758"
         )
         self.assertEqual("altha@email.co.uk", result["email"])
+
+    def test_get_user_by_anon_project_specific_user_id_not_found(self):
+        with self.assertRaises(AssertionError):
+            self.core_client.get_user_by_anon_project_specific_user_id(
+                anon_project_specific_user_id="1a03cb39-b669-44bb-a69e-98e6a521d757"
+            )
 
     def test_get_user_task_from_anon_user_task_id_ok(self):
         result = self.core_client.get_user_task_from_anon_user_task_id(

--- a/thiscovery_lib/core_api_utilities.py
+++ b/thiscovery_lib/core_api_utilities.py
@@ -30,7 +30,9 @@ class CoreApiClient(tau.ThiscoveryApiClient):
 
     @tau.check_response(HTTPStatus.OK, HTTPStatus.NOT_FOUND)
     def get_user_by_user_id(self, user_id):
-        return utils.aws_get(endpoint_url=f"v1/user/{user_id}", base_url=self.base_url)
+        return utils.aws_get(
+            endpoint_url=f"v1/userv2/{user_id}", base_url=self.base_url
+        )
 
     @tau.process_response
     @tau.check_response(HTTPStatus.OK)
@@ -44,7 +46,7 @@ class CoreApiClient(tau.ThiscoveryApiClient):
     @tau.check_response(HTTPStatus.OK, HTTPStatus.NOT_FOUND)
     def get_user_by_anon_project_specific_user_id(self, anon_project_specific_user_id):
         return utils.aws_get(
-            "v1/user",
+            "v1/userv2",
             self.base_url,
             params={"anon_project_specific_user_id": anon_project_specific_user_id},
         )

--- a/thiscovery_lib/core_api_utilities.py
+++ b/thiscovery_lib/core_api_utilities.py
@@ -28,7 +28,6 @@ class CoreApiClient(tau.ThiscoveryApiClient):
     def ping(self):
         return utils.aws_get("v1/ping", self.base_url)
 
-    # @tau.process_response
     @tau.check_response(HTTPStatus.OK, HTTPStatus.NOT_FOUND)
     def get_user_by_user_id(self, user_id):
         return utils.aws_get(endpoint_url=f"v1/user/{user_id}", base_url=self.base_url)
@@ -42,7 +41,6 @@ class CoreApiClient(tau.ThiscoveryApiClient):
         user = self.get_user_by_email(email=email)
         return user["id"]
 
-    # @tau.process_response
     @tau.check_response(HTTPStatus.OK, HTTPStatus.NOT_FOUND)
     def get_user_by_anon_project_specific_user_id(self, anon_project_specific_user_id):
         return utils.aws_get(

--- a/thiscovery_lib/core_api_utilities.py
+++ b/thiscovery_lib/core_api_utilities.py
@@ -43,10 +43,11 @@ class CoreApiClient(tau.ThiscoveryApiClient):
         user = self.get_user_by_email(email=email)
         return user["id"]
 
-    @tau.check_response(HTTPStatus.OK, HTTPStatus.NOT_FOUND)
+    @tau.process_response
+    @tau.check_response(HTTPStatus.OK)
     def get_user_by_anon_project_specific_user_id(self, anon_project_specific_user_id):
         return utils.aws_get(
-            "v1/userv2",
+            "v1/user",
             self.base_url,
             params={"anon_project_specific_user_id": anon_project_specific_user_id},
         )

--- a/thiscovery_lib/core_api_utilities.py
+++ b/thiscovery_lib/core_api_utilities.py
@@ -29,7 +29,7 @@ class CoreApiClient(tau.ThiscoveryApiClient):
         return utils.aws_get("v1/ping", self.base_url)
 
     @tau.process_response
-    @tau.check_response((HTTPStatus.OK, HTTPStatus.NOT_FOUND))
+    @tau.check_response(HTTPStatus.OK, HTTPStatus.NOT_FOUND)
     def get_user_by_user_id(self, user_id):
         return utils.aws_get(endpoint_url=f"v1/user/{user_id}", base_url=self.base_url)
 

--- a/thiscovery_lib/core_api_utilities.py
+++ b/thiscovery_lib/core_api_utilities.py
@@ -28,7 +28,7 @@ class CoreApiClient(tau.ThiscoveryApiClient):
     def ping(self):
         return utils.aws_get("v1/ping", self.base_url)
 
-    @tau.process_response
+    # @tau.process_response
     @tau.check_response(HTTPStatus.OK, HTTPStatus.NOT_FOUND)
     def get_user_by_user_id(self, user_id):
         return utils.aws_get(endpoint_url=f"v1/user/{user_id}", base_url=self.base_url)
@@ -42,8 +42,8 @@ class CoreApiClient(tau.ThiscoveryApiClient):
         user = self.get_user_by_email(email=email)
         return user["id"]
 
-    @tau.process_response
-    @tau.check_response(HTTPStatus.OK)
+    # @tau.process_response
+    @tau.check_response(HTTPStatus.OK, HTTPStatus.NOT_FOUND)
     def get_user_by_anon_project_specific_user_id(self, anon_project_specific_user_id):
         return utils.aws_get(
             "v1/user",

--- a/thiscovery_lib/core_api_utilities.py
+++ b/thiscovery_lib/core_api_utilities.py
@@ -29,7 +29,7 @@ class CoreApiClient(tau.ThiscoveryApiClient):
         return utils.aws_get("v1/ping", self.base_url)
 
     @tau.process_response
-    @tau.check_response(HTTPStatus.OK)
+    @tau.check_response((HTTPStatus.OK, HTTPStatus.NOT_FOUND))
     def get_user_by_user_id(self, user_id):
         return utils.aws_get(endpoint_url=f"v1/user/{user_id}", base_url=self.base_url)
 


### PR DESCRIPTION
## Motivation

Check the response status rather than waiting for `process_response` to raise an error because it got an unexpected 404

## Source code changes

Remove the `process_response` decorator from `get_user_by_user_id` (this was stripping the status)

Allow HTTPStatus.NOT_FOUND in the `check_response` decorator allowed statuses (this was throwing the assertion error)

Update URL to call the new endpoint at `v1/userv2/{user_id}`

## Tests

- test_get_user_by_user_id_ok
  Add statusCode check

- test_get_user_by_user_id_not_found 
  Add test

- test_get_user_by_anon_project_specific_user_id_not_found
  Check AssertionError is raised. This is a missing test, testing unchanged code. 

## Deployment

The update order should be:

1. core
2. lib
3. crm/surveys

surveys and crm are using branch sophie/4723_get_user_by_user_id_allow_404. Once this is merged, put these stacks' requirements back to master.