### PR TITLE
Adds SendGridClient

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setuptools.setup(
         "requests",
         "simplejson",
         "validators",
+        "sendgrid",
     ],
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_external_integrations/test_sendgrid.py
+++ b/tests/test_external_integrations/test_sendgrid.py
@@ -1,19 +1,26 @@
+from http import HTTPStatus
+
 import local.dev_config
 import local.secrets
 
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
 
-from thiscovery_lib.sendgrid_utilities import SendGridClient
+from thiscovery_lib.sendgrid_utilities import EmailError, SendGridClient
 
 
 class TestSendGridClient(TestCase):
     def setUp(self):
         with patch("thiscovery_lib.sendgrid_utilities.get_secret"):
             self.sendgrid_client = SendGridClient(
-                {"email": "test@example.org", "name": "test"},
-                {"first_name": "Test"},
-                "d-123",
+                sending_data={
+                    "email": "test@example.org",
+                    "name": "test",
+                    "from_email": ("thiscovery@thisinstitute.cam.ac.uk", "thiscovery"),
+                    "reply_to": ("thiscovery@thisinstitute.cam.ac.uk", "thiscovery"),
+                },
+                template_data={"first_name": "Test"},
+                template_id="d-123",
             )
 
     def test_client(self):
@@ -22,7 +29,7 @@ class TestSendGridClient(TestCase):
     @patch("thiscovery_lib.sendgrid_utilities.SendGridAPIClient.send")
     def test_send_email(self, mocked_send):
         mocked_response = MagicMock()
-        mocked_response.status_code = 202
+        mocked_response.status_code = HTTPStatus.ACCEPTED
         mocked_send.return_value = mocked_response
 
         self.sendgrid_client.send_email()
@@ -30,9 +37,14 @@ class TestSendGridClient(TestCase):
 
     def test_create_message(self):
         mail = self.sendgrid_client._create_message(
-            {"email": "test@example.org", "name": "test"},
-            {"first_name": "hello"},
-            "d-123",
+            sending_data={
+                "email": "test@example.org",
+                "name": "test",
+                "from_email": ("thiscovery@thisinstitute.cam.ac.uk", "thiscovery"),
+                "reply_to": ("thiscovery@thisinstitute.cam.ac.uk", "thiscovery"),
+            },
+            template_data={"first_name": "Test"},
+            template_id="d-123",
         )
 
         assert mail.personalizations[0].tos[0].get("email") == "test@example.org"
@@ -42,3 +54,14 @@ class TestSendGridClient(TestCase):
         assert mail.reply_to.email == "thiscovery@thisinstitute.cam.ac.uk"
         assert mail.reply_to.name == "thiscovery"
         assert mail.template_id is not None
+
+    def test_send_email_error(self):
+        with patch(
+            "thiscovery_lib.sendgrid_utilities.SendGridAPIClient.send"
+        ) as mocked_send:
+            mocked_response = MagicMock()
+            mocked_response.status_code = HTTPStatus.BAD_REQUEST
+            mocked_send.return_value = mocked_response
+
+            with self.assertRaises(EmailError):
+                self.sendgrid_client.send_email()

--- a/tests/test_external_integrations/test_sendgrid.py
+++ b/tests/test_external_integrations/test_sendgrid.py
@@ -1,0 +1,44 @@
+import local.dev_config
+import local.secrets
+
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+from thiscovery_lib.sendgrid_utilities import SendGridClient
+
+
+class TestSendGridClient(TestCase):
+    def setUp(self):
+        with patch("thiscovery_lib.sendgrid_utilities.get_secret"):
+            self.sendgrid_client = SendGridClient(
+                {"email": "test@example.org", "name": "test"},
+                {"first_name": "Test"},
+                "d-123",
+            )
+
+    def test_client(self):
+        assert self.sendgrid_client is not None
+
+    @patch("thiscovery_lib.sendgrid_utilities.SendGridAPIClient.send")
+    def test_send_email(self, mocked_send):
+        mocked_response = MagicMock()
+        mocked_response.status_code = 202
+        mocked_send.return_value = mocked_response
+
+        self.sendgrid_client.send_email()
+        mocked_send.assert_called()
+
+    def test_create_message(self):
+        mail = self.sendgrid_client._create_message(
+            {"email": "test@example.org", "name": "test"},
+            {"first_name": "hello"},
+            "d-123",
+        )
+
+        assert mail.personalizations[0].tos[0].get("email") == "test@example.org"
+        assert mail.personalizations[0].tos[0].get("name") == "test"
+        assert mail.from_email.email == "thiscovery@thisinstitute.cam.ac.uk"
+        assert mail.from_email.name == "thiscovery"
+        assert mail.reply_to.email == "thiscovery@thisinstitute.cam.ac.uk"
+        assert mail.reply_to.name == "thiscovery"
+        assert mail.template_id is not None

--- a/thiscovery_lib/sendgrid_utilities.py
+++ b/thiscovery_lib/sendgrid_utilities.py
@@ -1,0 +1,53 @@
+from sendgrid import SendGridAPIClient
+from sendgrid.helpers.mail import Mail
+
+from thiscovery_lib.utilities import get_secret
+
+
+BASE_API_ENDPOINT = "https://api.sendgrid.com/v3"
+
+
+class EmailError(Exception):
+    pass
+
+
+class SendGridClient:
+    """
+    Utilitly client for sending email via our SendGrid account.
+    """
+
+    def __init__(self, sending_data, template_data, template_id):
+        """
+        args:
+            sending_data (dict): contains the email and name of the email receipient
+            template_data (dict): contains data used to populate variables in
+                the email template
+            template_id (string): the id of the template to use for this email
+        """
+        self.sendgrid_api_client = SendGridAPIClient(self._get_api_key())
+        self.mail = self._create_message(sending_data, template_data, template_id)
+
+    def _create_message(self, sending_data, template_data, template_id):
+        """
+        Accepts all the same arguments as the __init__ method and uses them to
+        build the email which will be sent.
+        """
+        mail = Mail()
+        mail.add_to((sending_data["email"], sending_data["name"]))
+        mail.from_email = ("thiscovery@thisinstitute.cam.ac.uk", "thiscovery")
+        mail.reply_to = ("thiscovery@thisinstitute.cam.ac.uk", "thiscovery")
+        mail.template_id = template_id
+        mail.dynamic_template_data = template_data
+
+        return mail
+
+    def _get_api_key(self):
+        return get_secret("sendgrid-api-key")
+
+    def send_email(self):
+        response = self.sendgrid_api_client.send(self.mail)
+
+        if response.status_code != 202:
+            raise EmailError(
+                f"Unexpected status code: {response.status_code}. We received this from SendGrid: {response.body}"
+            )

--- a/thiscovery_lib/sendgrid_utilities.py
+++ b/thiscovery_lib/sendgrid_utilities.py
@@ -51,3 +51,5 @@ class SendGridClient:
             raise EmailError(
                 f"Unexpected status code: {response.status_code}. We received this from SendGrid: {response.body}"
             )
+
+        return response

--- a/thiscovery_lib/sendgrid_utilities.py
+++ b/thiscovery_lib/sendgrid_utilities.py
@@ -1,10 +1,9 @@
+from http import HTTPStatus
+
 from sendgrid import SendGridAPIClient
 from sendgrid.helpers.mail import Mail
 
 from thiscovery_lib.utilities import get_secret
-
-
-BASE_API_ENDPOINT = "https://api.sendgrid.com/v3"
 
 
 class EmailError(Exception):
@@ -34,8 +33,8 @@ class SendGridClient:
         """
         mail = Mail()
         mail.add_to((sending_data["email"], sending_data["name"]))
-        mail.from_email = ("thiscovery@thisinstitute.cam.ac.uk", "thiscovery")
-        mail.reply_to = ("thiscovery@thisinstitute.cam.ac.uk", "thiscovery")
+        mail.from_email = sending_data["from_email"]
+        mail.reply_to = sending_data["reply_to"]
         mail.template_id = template_id
         mail.dynamic_template_data = template_data
 
@@ -47,7 +46,7 @@ class SendGridClient:
     def send_email(self):
         response = self.sendgrid_api_client.send(self.mail)
 
-        if response.status_code != 202:
+        if response.status_code != HTTPStatus.ACCEPTED:
             raise EmailError(
                 f"Unexpected status code: {response.status_code}. We received this from SendGrid: {response.body}"
             )


### PR DESCRIPTION
Creates a SendGridClient to be used in thiscovery-crm to send emails via sendgrid, instead of HubSpot.

To test sending an email you can use a script like this. You'll need to set the API key secret in your secret manager. If you message me I can send you the API key (or I can add you to the sendgrid project where you can fetch it).

```
from thiscovery_lib.sendgrid_utilities import SendGridClient
import local.secrets
import local.dev_config

sendgrid_client = SendGridClient(
    {"email": "{your_email}", "name": "{your_name}",
    {"first_name": "{your_first_name}"},
    "d-f837734467f8422ca3886d17ed297b23"
)
sendgrid_client.send_email()
```